### PR TITLE
Require active_support/core/obect for .present?

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -4,7 +4,7 @@ Inspired by the mc-settings and config gems, but with a simpler code base and mo
 
 == Installation
 
-Just include the screwdriver gem in your Bundler Gemfile
+Just include the easy-settings gem in your Bundler Gemfile
 
   gem "easy-settings"
 

--- a/lib/easy-settings/env_source.rb
+++ b/lib/easy-settings/env_source.rb
@@ -1,4 +1,5 @@
 require "easy-settings/path_source"
+require "active_support/core_ext/object"
 
 class EasySettings::EnvSource < EasySettings::PathSource
   attr_reader :prefix


### PR DESCRIPTION
This PR fixes a missing active_support dependency in env_source.rb